### PR TITLE
[DEVOPS-6963] Try to define the more clear neme for the build linked to deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -5,7 +5,7 @@ name: Deploy Dev
 
 on: 
   workflow_run:
-    workflows: ['build']
+    workflows: ['build.yml']
     types:
       - completed
   


### PR DESCRIPTION
https://strongmind.atlassian.net/browse/DEVOPS-6963

## Purpose 
Migrate eventgrid-viewer-blazor Build and Release Pipeline from Azure DevOps to GitHub Actions

## Approach 
Add Dotnet build configuration from Global-build repo

## Testing
Test build and deploy on DEV

## Screenshots/Video
TBD