### PR TITLE
BEL-3046: Update dependabot_auto_merge.yml | Squashing no longer allowed

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,12 +1,11 @@
 name: Dependabot Pull Request Approve and Merge
 
-
 on:
- push:
+  push:
     branches:
       - 'main'
       - 'master'
- pull_request_target:
+  pull_request_target:
     branches:
       - 'main'
       - 'master'
@@ -14,29 +13,10 @@ on:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
-    # Checking the actor will prevent your Action run failing on non-Dependabot
-    # PRs but also ensures that it only does work for Dependabot PRs.
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      # This first step will fail if there's no metadata and so the approval
-      # will not occur.
-      - name: Dependabot metadata
-        id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.1.1
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      # Here the PR gets approved.
-      - name: Approve a PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Finally, this sets the PR to allow auto-merging for patch and minor
-      # updates if all checks pass
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: StrongMind/public-reusable-workflows/.github/workflows/shared-dependabot-auto-merge.yml@main
+    with:
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      github_actor: ${{ github.actor }}
+    secrets: inherit
+    if: ${{ github.actor == 'dependabot[bot]'}}
+


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-3046)

## Purpose 
<!-- what/why -->
Update dependabot-auto-merge workflow to use --merge instead of --squash as squashing is no longer allowed

## Approach 
<!-- how -->
The workflow now calls the shared workflow in Public Reusable Workflows repo to approve and merge the PR from dependabot

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
Tested it out on repo-dashboard to see if dependabot PR's will auto-merge. Tests were successful.
Tested sucessfully on repository-dashboard where dependabot PR's were auto-merged.

## Screenshots/Video
<!-- show before/after of the change if possible -->
Before(Actions were failing):
<img width="1162" alt="image" src="https://github.com/StrongMind/repository-dashboard/assets/172301408/5e9d4ae7-c06b-41f9-a0a4-d31aaf64d3cb">
After(Actions get passed and PR's are auto-merged):
<img width="670" alt="image" src="https://github.com/StrongMind/repository-dashboard/assets/172301408/8c85b69e-c214-4706-b292-42a8241c51d0">

