### PR TITLE
Update CODEOWNERS to use next-level team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 # assigned to each repo and setting them as CodeOwner over the
 # entire repository
 
-* @StrongMind/horseshoes
+* @StrongMind/next-level


### PR DESCRIPTION
This PR updates the CODEOWNERS file to use the next-level team.

Changes made:
- Replaced '* @StrongMind/horseshoes' with '* @StrongMind/next-level'
